### PR TITLE
Publish library before pack

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,9 +43,7 @@ jobs:
       - name: Package Nightly Nuget 📦
         run: |
           SUFFIX=`date "+%y%m%d%H%M%S"`
-          dotnet publish -c Release src/AntDesign.Charts -f netstandard2.1
-          dotnet publish -c Release src/AntDesign.Charts -f net5.0
-          dotnet pack src/AntDesign.Charts/AntDesign.Charts.csproj /p:PackageVersion=$Version-nightly-${SUFFIX} -c Release -o publish --no-build --no-restore
+          dotnet pack src/AntDesign.Charts/AntDesign.Charts.csproj /p:PackageVersion=$Version-nightly-${SUFFIX} -c Release -o publish
 
       - name: Publish to Nuget ✔
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Package Nightly Nuget 📦
         run: |
           SUFFIX=`date "+%y%m%d%H%M%S"`
+          dotnet publish -c Release src/AntDesign.Charts -f netstandard2.1
+          dotnet publish -c Release src/AntDesign.Charts -f net5.0
           dotnet pack src/AntDesign.Charts/AntDesign.Charts.csproj /p:PackageVersion=$Version-nightly-${SUFFIX} -c Release -o publish --no-build --no-restore
 
       - name: Publish to Nuget ✔


### PR DESCRIPTION
`dotnet pack` try to pack `net5.0` and `netstandard2.1` versions to nuget package, but [can't find second one](https://github.com/ant-design-blazor/ant-design-charts-blazor/runs/2515644518?check_suite_focus=true)

To correct packing need to publish a library for both target frameworks first. 