### PR TITLE
Use g2plot.min.js

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -19,7 +19,7 @@
 - 在 `wwwroot/index.html`(WebAssembly) 或 `Pages/_Host.razor`(Server) 中引入静态文件:
 
   ```html
-  <script src="https://unpkg.com/@antv/g2plot@latest/dist/g2plot.js"></script>
+  <script src="https://unpkg.com/@antv/g2plot@latest/dist/g2plot.min.js"></script>
   <script src="_content/AntDesign.Charts/ant-design-charts-blazor.js"></script>
   ```
   

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ English | [简体中文](README-zh_CN.md)
   - Link the static files in `wwwroot/index.html` (WebAssembly) or `Pages/_Host.razor` (Server)
 
   ```html
-  <script src="https://unpkg.com/@antv/g2plot@latest/dist/g2plot.js"></script>
+  <script src="https://unpkg.com/@antv/g2plot@latest/dist/g2plot.min.js"></script>
   <script src="_content/AntDesign.Charts/ant-design-charts-blazor.js"></script>
   ```
   

--- a/src/AntDesign.Charts.Docs.WebAssembly/wwwroot/gh-pages/index.html
+++ b/src/AntDesign.Charts.Docs.WebAssembly/wwwroot/gh-pages/index.html
@@ -12,7 +12,7 @@
     <link href="css/app.css" rel="stylesheet" />
     <link href="manifest.json" rel="manifest" />
     <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
-    <script src="https://unpkg.com/@antv/g2plot@latest/dist/g2plot.js"></script>
+    <script src="https://unpkg.com/@antv/g2plot@latest/dist/g2plot.min.js"></script>
     <script src="_content/AntDesign.Charts/ant-design-charts-blazor.js"></script>
 </head>
 


### PR DESCRIPTION
In g2plot v1 general file was called `g2plot.js` - https://unpkg.com/browse/@antv/g2plot@1.1.28/dist/

But in v2 that file called `g2plot.min.js` - https://unpkg.com/browse/@antv/g2plot@2.0.0/dist/

In `gh-pages/index.html` and `README` incorrect file name was fixed