### PR TITLE
Fixed Gauge Chart serialization

### DIFF
--- a/src/AntDesign.Charts/Components/Configs/IGraphicStyle.cs
+++ b/src/AntDesign.Charts/Components/Configs/IGraphicStyle.cs
@@ -8,6 +8,7 @@ namespace AntDesign.Charts
     [JsonDerivedType(typeof(TextStyle))]
     [JsonDerivedType(typeof(LegendMarkerStyle))]
     [JsonDerivedType(typeof(GraphicStyle))]
+    [JsonDerivedType(typeof(GaugeStyle))]
     public interface IGraphicStyle
     {
         [JsonPropertyName("fill")]


### PR DESCRIPTION
 A fix for the following exception when rendering Gauge Chart with .Net8.

`
 System.AggregateException: One or more errors occurred. (Runtime type 'AntDesign.Charts.GaugeStyle' is not supported by polymorphic type 'AntDesign.Charts.IGraphicStyle'. The unsupported member type is located on type 'System.Object'. Path: $.IndicatorMapping.Pointer.StyleMapping.)
 `