### PR TITLE
Refactor data handling in ChartComponentBase for improved configuration support

### DIFF
--- a/src/AntDesign.Charts/Components/Base/ChartComponentBase.cs
+++ b/src/AntDesign.Charts/Components/Base/ChartComponentBase.cs
@@ -178,12 +178,8 @@ namespace AntDesign.Charts
 
             if (csData != null && Config is IViewConfig viewConfig)
             {
+                Data = csData;
                 SetIViewConfig(viewConfig);
-            }
-
-            if (csData != null && Config is ScatterConfig scatterConfig)
-            {
-                scatterConfig.Data = csData;
             }
 
             if (IsCreated == false)


### PR DESCRIPTION
This commit simplifies data assignment in the ChartComponentBase by directly setting the Data property when a valid IViewConfig is provided. The previous handling for ScatterConfig has been removed to streamline the code, enhancing maintainability and clarity in data management for chart components.

fixed #154